### PR TITLE
tc4tweak researchbrowser page compat

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/compat/Mods.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/compat/Mods.java
@@ -1,0 +1,35 @@
+package dev.rndmorris.salisarcana.common.compat;
+
+import java.util.function.Supplier;
+
+import cpw.mods.fml.common.Loader;
+
+public enum Mods {
+
+    TC4Tweak("tc4tweak"),;
+
+    public final String modid;
+    private final Supplier<Boolean> supplier;
+    private Boolean loaded; // class version so it is nullable
+
+    Mods(String modid) {
+        this.modid = modid;
+        this.supplier = null;
+    }
+
+    Mods(Supplier<Boolean> supplier) {
+        this.supplier = supplier;
+        this.modid = null;
+    }
+
+    public boolean isLoaded() {
+        if (loaded == null) {
+            if (supplier != null) {
+                loaded = supplier.get();
+            } else if (modid != null) {
+                loaded = Loader.isModLoaded(modid);
+            } else loaded = false;
+        }
+        return loaded;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchBrowser_Creative_Scroll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchBrowser_Creative_Scroll.java
@@ -81,6 +81,20 @@ public abstract class MixinGuiResearchBrowser_Creative_Scroll extends GuiScreen 
                     categories.addAll(
                         BrowserPaging.getTabsOnCurrentPage(this.player)
                             .keySet());
+
+                    // tc4tweaks page can be empty because of eldritch tab
+                    if (categories.isEmpty()) return;
+
+                    // reset to first if current category is not found
+                    if (!categories.contains(selectedCategory)) {
+                        selectedCategory = categories.get(0);
+                        this.updateResearch();
+                        return;
+                    }
+                    // where does a list of size 1 scroll to?
+                    if (categories.size() == 1) {
+                        return;
+                    }
                 } else {
                     for (String category : ResearchCategories.researchCategories.keySet()) {
                         if (category.equals("ELDRITCH")
@@ -89,20 +103,6 @@ public abstract class MixinGuiResearchBrowser_Creative_Scroll extends GuiScreen 
                         }
                         categories.add(category);
                     }
-                }
-
-                // tc4tweaks page can be empty because of eldritch tab
-                if (categories.isEmpty()) return;
-
-                // reset to first if current category is not found
-                if (!categories.contains(selectedCategory)) {
-                    selectedCategory = categories.get(0);
-                    this.updateResearch();
-                    return;
-                }
-                // where does a list of size 1 scroll to?
-                if (categories.size() == 1) {
-                    return;
                 }
 
                 dir *= sa$invertScrolling;


### PR DESCRIPTION
Adds an easy (and cached) check if TC4Tweak is loaded  

Ctrl+scroll is now only between categories on the current page